### PR TITLE
Fixing "email us" link.

### DIFF
--- a/post.md
+++ b/post.md
@@ -77,4 +77,4 @@ By participating in this competition, you, the Author, certify that you created 
 
 ## More questions? 
 
-Email us at [team@airpair.com](team@airpair.com)!
+Email us at [team@airpair.com](mailto:team@airpair.com)!


### PR DESCRIPTION
The "email us" link was mixing a prefixing "mailto:" and causing some browsers to just try to take you to a relative URL.
